### PR TITLE
[FEATURE]: the component instance is now available as `this` for non [phat]Arrow

### DIFF
--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -23,11 +23,11 @@ export default (stateToComputed, dispatchToActions=() => ({})) => {
       init() {
         const redux = this.get('redux');
 
-        let props = stateToComputed(redux.getState(), this.getAttrs());
+        let props = stateToComputed.call(this, redux.getState(), this.getAttrs());
 
         Object.keys(props).forEach(name => {
           defineProperty(this, name, computed(() =>
-            stateToComputed(redux.getState(), this.getAttrs())[name]
+            stateToComputed.call(this, redux.getState(), this.getAttrs())[name]
           ).property().readOnly());
         });
 
@@ -38,7 +38,7 @@ export default (stateToComputed, dispatchToActions=() => ({})) => {
         }
 
         this.actions = Object.assign({},
-          this.actions, dispatchToActions(redux.dispatch.bind(redux))
+          this.actions, dispatchToActions.call(this, redux.dispatch.bind(redux))
         );
 
         this._super(...arguments);
@@ -47,7 +47,7 @@ export default (stateToComputed, dispatchToActions=() => ({})) => {
       handleChange() {
         const redux = this.get('redux');
 
-        const props = stateToComputed(redux.getState(), this.getAttrs());
+        const props = stateToComputed.call(this, redux.getState(), this.getAttrs());
 
         const notifyProperties = Object.keys(props).filter(name => {
           return this.get(name) !== props[name];

--- a/tests/acceptance/rerender-test.js
+++ b/tests/acceptance/rerender-test.js
@@ -13,6 +13,20 @@ module('Acceptance | rerender test', {
   }
 });
 
+test('dispatchToActions will provide `this` context that is the component instance (when not using [phat]Arrow function)', function(assert) {
+  ajax('/api/lists', 'GET', 200, [{id: 1, name: 'one', reviews: [{rating: 5}, {rating: 5}]}, {id: 2, name: 'two', reviews: [{rating: 3}, {rating: 1}]}]);
+  visit('/lists');
+  andThen(() => {
+    assert.equal(currentURL(), '/lists');
+    assert.equal(find('.fake-contextt').text(), '');
+  });
+  click('.btn-contextt');
+  andThen(() => {
+    assert.equal(currentURL(), '/lists');
+    assert.equal(find('.fake-contextt').text(), 'contextt ... abc123');
+  });
+});
+
 test('should only rerender when connected component is listening for each state used to compute', function(assert) {
   ajax('/api/lists', 'GET', 200, [{id: 1, name: 'one', reviews: [{rating: 5}, {rating: 5}]}, {id: 2, name: 'two', reviews: [{rating: 3}, {rating: 1}]}]);
   visit('/lists');

--- a/tests/dummy/app/components/count-list/component.js
+++ b/tests/dummy/app/components/count-list/component.js
@@ -2,11 +2,13 @@ import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import connect from 'ember-redux/components/connect';
 
-var stateToComputed = (state, attrs) => {
+var stateToComputed = function(state, attrs) {
+  var component = this;
   return {
     low: state.low,
     high: state.high,
-    greeting: `Welcome back, ${attrs.name}!`
+    greeting: `Welcome back, ${attrs.name}!`,
+    serviced: component.get('fake.serviced')
   };
 };
 
@@ -18,6 +20,7 @@ var dispatchToActions = (dispatch) => {
 };
 
 var CountListComponent = Ember.Component.extend({
+  fake: Ember.inject.service(),
   layout: hbs`
     <span class="parent-state">{{low}}</span>
     <button class="btn-up" onclick={{action "up"}}>up</button>
@@ -26,6 +29,7 @@ var CountListComponent = Ember.Component.extend({
     <button class="btn-alter" onclick={{action "alter"}}>alter</button>
     <span class="random-state">{{color}}</span>
     <span class="greeting">{{greeting}}</span>
+    <span class="serviced">{{serviced}}</span>
   `,
   actions: {
     alter() {

--- a/tests/dummy/app/components/count-list/component.js
+++ b/tests/dummy/app/components/count-list/component.js
@@ -8,7 +8,8 @@ var stateToComputed = function(state, attrs) {
     low: state.low,
     high: state.high,
     greeting: `Welcome back, ${attrs.name}!`,
-    serviced: component.get('fake.serviced')
+    serviced: component.get('fake.serviced'),
+    dyno: `name: ${component.get('dynoName')}`
   };
 };
 
@@ -20,6 +21,10 @@ var dispatchToActions = (dispatch) => {
 };
 
 var CountListComponent = Ember.Component.extend({
+  dynoNameValue: null,
+  dynoName: Ember.computed('dynoNameValue', function() {
+    return this.get('dynoNameValue');
+  }),
   fake: Ember.inject.service(),
   layout: hbs`
     <span class="parent-state">{{low}}</span>
@@ -30,6 +35,7 @@ var CountListComponent = Ember.Component.extend({
     <span class="random-state">{{color}}</span>
     <span class="greeting">{{greeting}}</span>
     <span class="serviced">{{serviced}}</span>
+    <span class="dyno">{{dyno}}</span>
   `,
   actions: {
     alter() {

--- a/tests/dummy/app/components/list-one/component.js
+++ b/tests/dummy/app/components/list-one/component.js
@@ -7,23 +7,27 @@ import filterRating from 'dummy/utilities/filter';
 var stateToComputed = (state) => {
   return {
     items: filterRating(state.list.all, state.list.filter),
-    fake: state.list.fake
+    fake: state.list.fake,
+    contextt: state.list.contextt
   };
 };
 
-var dispatchToActions = (dispatch) => {
+var dispatchToActions = function(dispatch) {
+  var component = this;
   return {
     filter: (filter) => dispatch({type: 'FILTER_LIST', filter: filter}),
     refresh: () => ajax('/api/lists', 'GET').then(response => dispatch({type: 'TRANSFORM_LIST', response: response})),
     update: () => dispatch({type: 'UNRELATED_UPDATE'}),
     random: () => dispatch({type: 'RANDOM_UPDATE'}),
-    faked: () => dispatch({type: 'FAKE_UPDATE'})
+    faked: () => dispatch({type: 'FAKE_UPDATE'}),
+    context: () => dispatch({type: 'THIS_CONTEXT_EXAMPLE', value: component.get('valuee')})
   };
 };
 
 var ListOneComponent = Ember.Component.extend({
+  valuee: 'abc123',
   layout: hbs`
-    {{yield items fake (action "filter") (action "refresh") (action "update") (action "random") (action "faked")}}
+    {{yield items fake contextt (action "filter") (action "refresh") (action "update") (action "random") (action "faked") (action "context")}}
   `
 });
 

--- a/tests/dummy/app/lists/template.hbs
+++ b/tests/dummy/app/lists/template.hbs
@@ -1,5 +1,5 @@
 <div class="list-item-one">
-  {{#list-one as |items fake filter|}}
+  {{#list-one as |items fake contextt filter|}}
     {{filter-list filter=filter value="5"}}
     {{list-html items=items fake=fake}}
   {{/list-one}}
@@ -13,12 +13,14 @@
 </div>
 
 <div class="list-item-three">
-  {{#list-one as |items fake filter refresh update random faked|}}
+  {{#list-one as |items fake contextt filter refresh update random faked context|}}
     {{refresh-list refresh=refresh}}
     {{unrelated-change update=update}}
     {{random-change random=random}}
     {{list-html items=items fake=fake}}
+    <span class="fake-contextt">{{contextt}}</span>
     <button class="fake-change" onclick={{action faked}}>update fake</button>
+    <button class="btn-contextt" onclick={{action context}}>test context</button>
   {{/list-one}}
 </div>
 

--- a/tests/dummy/app/reducers/list.js
+++ b/tests/dummy/app/reducers/list.js
@@ -27,13 +27,19 @@ export default ((state, action) => {
       unrelated: `unrelated ... ${Math.random()}`
     });
   }
+  if (action.type === 'THIS_CONTEXT_EXAMPLE') {
+    return Object.assign({}, state, {
+      contextt: `contextt ... ${action.value}`
+    });
+  }
   if (action.type === 'RANDOM_UPDATE') {
     return Object.assign({}, state, {
       random: Math.random(),
       all: state.all,
       filter: state.filter,
       unrelated: state.unrelated,
-      fake: state.fake
+      fake: state.fake,
+      contextt: state.contextt
     });
   }
   return state || initialState;

--- a/tests/dummy/app/services/fake.js
+++ b/tests/dummy/app/services/fake.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Service.extend({
+    serviced: true
+});

--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -50,6 +50,14 @@ test('should render attrs', function(assert) {
   assert.equal(this.$('.greeting').text(), 'Welcome back, Toran!', 'should rerender component if attrs change');
 });
 
+test('stateToComputed will provide `this` context that is the component instance (when not using [phat]Arrow function)', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`{{count-list}}`);
+
+  assert.equal(this.$('.serviced').text(), 'true', 'should render the prop provided by component instance');
+});
+
 test('the component should truly be extended meaning actions map over as you would expect', function(assert) {
   this.render(hbs`{{count-list}}`);
   let $random = this.$('.random-state');

--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -58,6 +58,19 @@ test('stateToComputed will provide `this` context that is the component instance
   assert.equal(this.$('.serviced').text(), 'true', 'should render the prop provided by component instance');
 });
 
+test('stateToComputed can be used with component level CP if notifyPropertyChange invoked during didUpdateAttrs', function(assert) {
+  assert.expect(2);
+
+  this.set('dynoNameValue', 'Toran');
+  this.render(hbs`{{count-list dynoNameValue=dynoNameValue}}`);
+
+  assert.equal(this.$('.dyno').text(), 'name: Toran', 'should render the local component value');
+
+  this.set('dynoNameValue', 'Tom');
+
+  assert.equal(this.$('.dyno').text(), 'name: Tom', 'should render new value when local component CP changed and notifyPropertyChange invoked');
+});
+
 test('the component should truly be extended meaning actions map over as you would expect', function(assert) {
   this.render(hbs`{{count-list}}`);
   let $random = this.$('.random-state');


### PR DESCRIPTION
@foxnewsnetwork was asking for a 3rd argument for `stateToComputed` that would allow the user to pull from non attrs.

This example shows how I can pull a value from an injected service w/ the api change mentioned.

The next PR that follows this should likely add attrs/ and the instance arguments to `dispatchToActions` (as react-redux supports `ownProps` and it would be consistent with `stateToComputed`)