### PR TITLE
fix(docs): wrap docs in {% raw %} tags

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 # Configure
 
 If you have a solid understanding of redux basics and what the ember bindings offer, this section will help you unlock the potential of ember-redux by showing all the extension points!
@@ -84,3 +86,5 @@ export default {
 [middleware]: https://github.com/reactjs/redux/blob/master/docs/Glossary.md#middleware
 [reducers]: https://github.com/reactjs/redux/blob/master/docs/Glossary.md#reducer
 [redux-thunk]: https://github.com/gaearon/redux-thunk
+
+{% endraw %}

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 # Cookbook
 
 **Using ember services to manage complex action creation**
@@ -20,7 +22,7 @@ export default Ember.Service.extend({
     redux.dispatch({type: 'ADD_TODO_REQUESTED', todoId});
     channels.get('todos').add(name)
       .receive('ok', resp => redux.dispatch({type: 'ADD_TODO_COMPLETED', todoId}))
-      .receive('error', resp => redux.dispatch({type: 'ADD_TODO_FAILED', todoId});
+      .receive('error', resp => redux.dispatch({type: 'ADD_TODO_FAILED', todoId}));
   }
 });
 ```
@@ -37,3 +39,5 @@ export default Ember.Component.extend({
   }
 });
 ```
+
+{% endraw %}

--- a/docs/ddau.md
+++ b/docs/ddau.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 # Data Down, Actions Up
 
 All of the examples so far have shown a single component but in real applications we build a tree of components each with a variety of responsibilities. In this short tutorial I hope to explain how redux has better informed my component design in ember by requiring the data down actions up paradigm.
@@ -199,3 +201,5 @@ Next learn about the different extension points by reading the [configuration](c
 [array]: https://gist.github.com/toranb/b661b53f9ab277ef8d4041cebe770414
 [idiomatic]: https://gist.github.com/toranb/8bf0b62841051dc64f1fa81299526a0a
 [github]: https://github.com/toranb/ember-redux-ddau-example
+
+{% endraw %}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 # ember-redux
 
 To install ember-redux
@@ -165,3 +167,5 @@ A quick recap of the 4 methods we use from redux.
 Note: One very important detail I'm skipping over is that when we return a new state of the application we should not mutate the previous state. Notice In my reducer function(s) above, we always return a new number (never change the existing number). The term for this concept is immutability and I'll discuss it in more detail later.
 
 Next, try the [quickstart](quickstart.md) to see the ember-redux API in action!
+
+{% endraw %}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,3 +1,5 @@
+{% raw %}
+
 # Quickstart
 
 Now that you have the hang of this redux thing lets take a look at what building that same component would look like using the `ember-redux` addon!
@@ -53,3 +55,5 @@ export default connect(stateToComputed, dispatchToActions)(NumbersComponent);
 And finally you will notice we use a new helper called `connect` to return a new component given the 2 functions that map the computed and actions.
 
 Next try this [example](https://ember-twiddle.com/7ce3446b14f166f04064eba663c0a350) in your web browser with ember-twiddle! Then continue reading about how to apply [data down/ actions up](ddau.md) with ember-redux!
+
+{% endraw %}


### PR DESCRIPTION
This escapes handlebars curly braces for Jekyll.

Fixes #83 
--patching into the beta/2x branch to keep it in sync with master