### PR TITLE
[DEPENDENCY]: upgraded redux/thunk shims in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "ember-lodash-shim": "1.0.1",
     "ember-maybe-import-regenerator": "0.1.4",
     "ember-redux-saga-shim": "0.1.0",
-    "ember-redux-shim": "^1.0.0",
-    "ember-redux-thunk-shim": "^1.0.0",
+    "ember-redux-shim": "^1.0.2",
+    "ember-redux-thunk-shim": "^1.1.1",
     "ember-resolver": "^2.0.3",
     "ember-symbol-observable": "0.1.2",
     "ember-try": "0.1.3",
@@ -52,7 +52,7 @@
     "lodash-es": "4.15.0",
     "redux": "^3.6.0",
     "redux-saga": "0.14.2",
-    "redux-thunk": "^2.1.0"
+    "redux-thunk": "^2.2.0"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Upgrade redux thunk and prepare the 2.0.0-beta.6 release (using beta/2x branch this time)