### PR TITLE
[DOCS]: update twiddle in the docs to point at v2.0 and fixed devTool…

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ export default UserTableComponent;
     ```js
     //app/enhancers/index.js
     import { compose } from 'redux';
-    var devtools = window.devToolsExtension ? window.devToolsExtension() : f => f;
+    var devtools = window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f;
     export default compose(devtools);
     ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -54,6 +54,6 @@ export default connect(stateToComputed, dispatchToActions)(NumbersComponent);
 
 And finally you will notice we use a new helper called `connect` to return a new component given the 2 functions that map the computed and actions.
 
-Next try this [example](https://ember-twiddle.com/7ce3446b14f166f04064eba663c0a350) in your web browser with ember-twiddle! Then continue reading about how to apply [data down/ actions up](ddau.md) with ember-redux!
+Next try this [example](https://ember-twiddle.com/2d98cd4418b7df5cbce6c5213351d31e) in your web browser with ember-twiddle! Then continue reading about how to apply [data down/ actions up](ddau.md) with ember-redux!
 
 {% endraw %}


### PR DESCRIPTION
I found the docs twiddle was still using the older ember-redux v1.0.0 example. In addition I wanted to update the devTools instructions to match this pull request https://github.com/zalmoxisus/redux-devtools-extension/pull/300