### PR TITLE
Bind action creators when dispatchToActions is an object

### DIFF
--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { bindActionCreators } from 'redux';
 
 const {
   computed,
@@ -37,9 +38,15 @@ export default (stateToComputed, dispatchToActions=() => ({})) => {
           });
         }
 
-        this.actions = Object.assign({},
-          this.actions, dispatchToActions.call(this, redux.dispatch.bind(redux))
-        );
+        if (typeof dispatchToActions === 'function') {
+          this.actions = Object.assign({},
+            this.actions, dispatchToActions.call(this, redux.dispatch.bind(redux))
+          );
+        }
+
+        if (typeof dispatchToActions === 'object') {
+          this.actions = Object.assign({}, this.actions, bindActionCreators.call(this, dispatchToActions, redux.dispatch.bind(redux)));
+        }
 
         this._super(...arguments);
       },

--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -136,3 +136,38 @@ test('connecting dispatchToActions only', function(assert) {
   this.render(hbs`{{test-component-1}}`);
   this.render(hbs`{{test-component-2}}`);
 });
+
+test('connecting dispatchToActions as object should dispatch action', function(assert) {
+  assert.expect(2);
+
+  const dispatchToActions = {
+    up() {
+      assert.ok(true, 'should be able to pass object of functions to dispatchToActions');
+      return {
+        type: 'UP'
+      };
+    },
+    down() {
+      assert.ok(true, 'should be able to pass object of functions to dispatchToActions');
+      return {
+        type: 'DOWN'
+      };
+    }
+  };
+
+  this.register('component:test-dispatch-action-object', connect(undefined, dispatchToActions)(Ember.Component.extend({
+    init() {
+      this._super(...arguments);
+    },
+    layout: hbs`
+      <button class="btn-up" onclick={{action "up"}}>up</button>
+      <button class="btn-down" onclick={{action "down"}}>up</button>
+    `
+  })));
+
+  this.render(hbs`{{test-dispatch-action-object}}`);
+  Ember.run(() => {
+    this.$('.btn-up').trigger('click');
+    this.$('.btn-down').trigger('click');
+  });
+});


### PR DESCRIPTION
This adds another thing that is possible to do in `react-redux`; pass an object to `dispatchToActions` and have them automatically bound to dispatch. This allows you to create action creators as separate functions, and have them automatically be dispatched instead of wrapping them in a `dispatch` call yourself.

Below is an example component after this change:

```js 
import { createPost } from 'module/action-creators';

const mapDispatchToActions = {
  createPost
};

// compared to 
/*
const mapDispatchToActions = (dispatch) => {
  createPost: () => dispatch(createPost())
});
*/

export default connect(undefined, mapDispatchToActions)(Ember.Component.extend({
  layout: hbs`
  <button onclick={{action "createPost"}}>Create post</button>
  `
}));
```

I've found myself using this exclusively in React, and I personally think it's nice to get rid of some boilerplate — of which there is already quite a bit when using Redux. 