### PR TITLE
[FEATURE]: unlock action creators

### DIFF
--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import { bindActionCreators } from 'redux';
 
 const {
   computed,
@@ -37,9 +38,16 @@ export default (stateToComputed, dispatchToActions=() => ({})) => {
           });
         }
 
-        this.actions = Object.assign({},
-          this.actions, dispatchToActions.call(this, redux.dispatch.bind(redux))
-        );
+        if (typeof dispatchToActions === 'function') {
+          this.actions = Object.assign({},
+            this.actions, dispatchToActions.call(this, redux.dispatch.bind(redux))
+          );
+        }
+
+        if (typeof dispatchToActions === 'object') {
+          this.actions = Object.assign({},
+            this.actions, bindActionCreators(dispatchToActions, redux.dispatch.bind(redux)));
+        }
 
         this._super(...arguments);
       },

--- a/tests/acceptance/async-dispatch-test.js
+++ b/tests/acceptance/async-dispatch-test.js
@@ -166,3 +166,24 @@ test('connected routes provide an ember route for you by default', function(asse
     assert.equal(find('.user-name').length, 2);
   });
 });
+
+test('connect supports action creator syntax', function(assert) {
+  visit('/actionz');
+  andThen(() => {
+    assert.equal(currentURL(), '/actionz');
+    assert.equal(find('.upp-low').text(), '0');
+  });
+  click('.btn-upp');
+  andThen(() => {
+    assert.equal(find('.upp-low').text(), '1');
+  });
+  click('.btn-upp');
+  andThen(() => {
+    assert.equal(find('.upp-low').text(), '2');
+  });
+  click('.btn-upp');
+  andThen(() => {
+    // remains 2 because of logic in the action
+    assert.equal(find('.upp-low').text(), '2');
+  });
+});

--- a/tests/dummy/app/actions/index.js
+++ b/tests/dummy/app/actions/index.js
@@ -1,0 +1,15 @@
+function bumpLow(number) {
+  return {
+    type: 'UPP',
+    number: number
+  }
+}
+
+export function bumpTwice(number) {
+  return function (dispatch, getState) {
+    if (getState().low > 1) {
+      return;
+    }
+    dispatch(bumpLow(number));
+  }
+}

--- a/tests/dummy/app/actionz/template.hbs
+++ b/tests/dummy/app/actionz/template.hbs
@@ -1,0 +1,1 @@
+{{less-boilerplate}}

--- a/tests/dummy/app/components/less-boilerplate/component.js
+++ b/tests/dummy/app/components/less-boilerplate/component.js
@@ -1,0 +1,23 @@
+import Ember from 'ember';
+import hbs from 'htmlbars-inline-precompile';
+import connect from 'ember-redux/components/connect';
+import { bumpTwice } from '../../actions/index';
+
+var stateToComputed = function(state) {
+  return {
+    low: state.low
+  };
+};
+
+var mapDispatchToActions = {
+  bumpTwice
+};
+
+var LessBoilerplateComponent = Ember.Component.extend({
+  layout: hbs`
+    <span class="upp-low">{{low}}</span>
+    <button class="btn-upp" onclick={{action "bumpTwice" 1}}>upp</button>
+  `
+});
+
+export default connect(stateToComputed, mapDispatchToActions)(LessBoilerplateComponent);

--- a/tests/dummy/app/reducers/low.js
+++ b/tests/dummy/app/reducers/low.js
@@ -2,5 +2,8 @@ export default ((state=0, action) => {
   if(action.type === 'UP') {
     return state + 1;
   }
+  if(action.type === 'UPP') {
+    return state + action.number;
+  }
   return state;
 });

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -22,6 +22,7 @@ Router.map(function() {
   this.route('super', { path: '/super' });
   this.route('thunk', { path: '/thunk' });
   this.route('simple', { path: '/simple' });
+  this.route('actionz', { path: '/actionz' });
 });
 
 export default Router;

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -9,3 +9,4 @@
 {{#link-to 'items' class='items-link'}}items{{/link-to}}
 {{#link-to 'fetch' class='fetch-link'}}fetch{{/link-to}}
 {{#link-to 'thunk' class='thunk-link'}}thunk{{/link-to}}
+{{#link-to 'actionz' class='actionz-link'}}action creators{{/link-to}}

--- a/tests/helpers/patch-middleware.js
+++ b/tests/helpers/patch-middleware.js
@@ -1,25 +1,37 @@
-/*global define:true*/
+/* global require, define */
 
-define('dummy/middleware/index', ['exports', 'ember', 'redux-saga', 'dummy/sagas/counter'], function (exports, _ember, createSaga, addAsync) {
-  while ('default' in addAsync) {
-    addAsync = addAsync.default;
-  }
+import originalMiddleware from 'dummy/middleware/index';
+import createSaga from 'redux-saga';
+import addAsync from 'dummy/sagas/counter';
 
-  while ('default' in createSaga) {
-    createSaga = createSaga.default;
-  }
+const { unsee } = require;
 
-  var sagaMiddleware = createSaga();
+export function applyPatch() {
+  unsee('dummy/services/redux');
+  unsee('dummy/middleware/index');
 
-  const setup = (...args) => {
-    window.middlewareArgs = args;
-    sagaMiddleware.run(addAsync);
-  };
+  define('dummy/middleware/index', ['exports'], function (exports) {
+    var sagaMiddleware = createSaga();
 
-  exports['default'] = {
-    middleware: [ sagaMiddleware ],
-    setup: setup
-  };
-});
+    const setup = (...args) => {
+      window.middlewareArgs = args;
+      sagaMiddleware.run(addAsync);
+    };
 
-export default function() {}
+    exports['default'] = {
+      middleware: [ sagaMiddleware ],
+      setup: setup
+    };
+  });
+}
+
+export function revertPatch() {
+  window.middlewareArgs = undefined;
+
+  unsee('dummy/services/redux');
+  unsee('dummy/middleware/index');
+
+  define('dummy/middleware/index', ['exports'], function (exports) {
+    exports['default'] = originalMiddleware;
+  });
+}

--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -138,3 +138,38 @@ test('connecting dispatchToActions only', function(assert) {
   this.render(hbs`{{test-component-1}}`);
   this.render(hbs`{{test-component-2}}`);
 });
+
+test('connecting dispatchToActions as object should dispatch action', function(assert) {
+  assert.expect(2);
+
+  const dispatchToActions = {
+    up() {
+      assert.ok(true, 'should be able to pass object of functions to dispatchToActions');
+      return {
+        type: 'UP'
+      };
+    },
+    down() {
+      assert.ok(true, 'should be able to pass object of functions to dispatchToActions');
+      return {
+        type: 'DOWN'
+      };
+    }
+  };
+
+  this.register('component:test-dispatch-action-object', connect(undefined, dispatchToActions)(Ember.Component.extend({
+    init() {
+      this._super(...arguments);
+    },
+    layout: hbs`
+      <button class="btn-up" onclick={{action "up"}}>up</button>
+      <button class="btn-down" onclick={{action "down"}}>up</button>
+    `
+  })));
+
+  this.render(hbs`{{test-dispatch-action-object}}`);
+  Ember.run(() => {
+    this.$('.btn-up').trigger('click');
+    this.$('.btn-down').trigger('click');
+  });
+});

--- a/tests/zlast/zmiddleware-test.js
+++ b/tests/zlast/zmiddleware-test.js
@@ -1,19 +1,18 @@
 import Ember from 'ember';
 import { test, module } from 'qunit';
-import patchMiddleware from '../helpers/patch-middleware';
+import { applyPatch, revertPatch } from '../helpers/patch-middleware';
 import startApp from '../helpers/start-app';
 
 var application;
 
 module('Acceptance | middleware configuration test', {
   beforeEach() {
-    window.middlewareArgs = null;
-    patchMiddleware();
+    applyPatch();
     application = startApp();
   },
   afterEach() {
     Ember.run(application, 'destroy');
-    window.middlewareArgs = null;
+    revertPatch();
   }
 });
 


### PR DESCRIPTION
I took the work @jkarsrud started and extended it to show a few points raised in the original [issue](https://github.com/ember-redux/ember-redux/pull/101). All credit for the action creator implementation goes to him - I just wanted to speed up some of this as it's possible I may use it in the near future.

1) I added acceptance tests that exercise it from end to end
2) I show the jQuery event issue mentioned by wrapping the action creator (still not sure how I feel about this ...)
3) I learned how this feature was intended to work by reading the [docs](http://redux.js.org/docs/recipes/ReducingBoilerplate.html) and used the "async action creator" as that would be how I'd likely use it in the wild

One issue I'm fighting with right now is that since the last middleware to boot is `redux-saga` (in the test suite) I get this fun error when I acceptance test it. Note: if I just run `ember s` it does indeed work as designed :) so I just need to hack a bit more until this darn middleware is setup correctly :)

![screen shot 2017-04-12 at 9 12 54 pm](https://cloud.githubusercontent.com/assets/147411/24987759/4c1f3710-1fc7-11e7-8c91-090c1217ac4b.png)


