### PR TITLE
Only call stateToComputed once per state update.

### DIFF
--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -2,39 +2,103 @@ import Ember from 'ember';
 import { bindActionCreators } from 'redux';
 
 const {
+  assert,
   computed,
   defineProperty,
+  getProperties,
   inject: { service },
-  isEmpty,
   run
 } = Ember;
 
-export default (stateToComputed, dispatchToActions=() => ({})) => {
+/**
+  Returns a list of keys that have different values between the two objects.
 
-  if (!stateToComputed) {
-    stateToComputed = () => ({});
-  }
+  @method changedKeys
+  @return {Array} keys that have changed
+  @private
+*/
+function changedKeys(state, newState) {
+  return Object.keys(state).filter(key => {
+    return state[key] !== newState[key];
+  });
+}
 
+/**
+  Creates a read-only computed property for accessing redux state.
+
+  @method computedReduxProperty
+  @return {Function} an Ember computed property
+  @private
+*/
+function computedReduxProperty(key, getState) {
+  return computed({
+    get: () => getState()[key],
+    set: () => assert(`Cannot set redux property "${key}".`)
+  });
+}
+
+/**
+  Return an object of attrs passed to this Component.
+
+  `Component.attrs` is an object that can look like this:
+
+    {
+      myAttr: {
+        value: 'myValue'
+      }
+    }
+
+  Ember provides that a `get` will return the value:
+
+    this.get('myAttr') === 'myValue'
+
+  @method getAttrs
+  @return {Object} an object of key, value for each attr
+  @private
+*/
+function getAttrs(context) {
+  const attrKeys = Object.keys(context.attrs || {});
+  return getProperties(context, attrKeys);
+}
+
+export default (stateToComputed, dispatchToActions) => {
   return Component => {
-
     return Component.extend({
-
       redux: service(),
 
       init() {
         const redux = this.get('redux');
 
-        let props = stateToComputed.call(this, redux.getState(), this.getAttrs());
+        if (stateToComputed) {
+          const getState = () => stateToComputed.call(this, redux.getState(), getAttrs(this));
 
-        Object.keys(props).forEach(name => {
-          defineProperty(this, name, computed(() =>
-            stateToComputed.call(this, redux.getState(), this.getAttrs())[name]
-          ).property().readOnly());
-        });
+          let state = getState();
 
-        if (!isEmpty(Object.keys(props))) {
-          this.unsubscribe = redux.subscribe(() => {
-            this.handleChange();
+          Object.keys(state).forEach(key => {
+            defineProperty(this, key, computedReduxProperty(key, () => state));
+          });
+
+          const handleChange = () => {
+            const newState = getState();
+            if (newState === state) return;
+
+            const propsToNotify = changedKeys(state, newState);
+
+            state = newState;
+
+            if (propsToNotify.length > 0) {
+              run.join(() => {
+                propsToNotify.forEach(key => this.notifyPropertyChange(key));
+              });
+            }
+          };
+
+          const unsubscribe = redux.subscribe(handleChange);
+
+          this.on('didUpdateAttrs', handleChange);
+          this.one('willDestroyElement', () => {
+            this.off('didReceiveAttrs', handleChange);
+            unsubscribe();
           });
         }
 
@@ -50,57 +114,6 @@ export default (stateToComputed, dispatchToActions=() => ({})) => {
         }
 
         this._super(...arguments);
-      },
-
-      handleChange() {
-        const redux = this.get('redux');
-
-        const props = stateToComputed.call(this, redux.getState(), this.getAttrs());
-
-        const notifyProperties = Object.keys(props).filter(name => {
-          return this.get(name) !== props[name];
-        });
-
-        if (notifyProperties.length > 0) {
-          run.join(() => {
-            notifyProperties.forEach(name => this.notifyPropertyChange(name));
-          });
-        }
-      },
-
-      /**
-       * Return an object of attrs passed to this Component.
-       *
-       * `Component.attrs` is an object that can look like this:
-       *
-       *   {
-       *     myAttr: {
-       *       value: 'myValue'
-       *     }
-       *   }
-       *
-       * Ember provides that a `get` will return the value:
-       *
-       *   this.get('myAttr') === 'myValue'
-       *
-       * @method getAttrs
-       * @private
-       */
-      getAttrs() {
-        return this.getProperties(Object.keys(this.attrs || {}));
-      },
-
-      didUpdateAttrs() {
-        this._super(...arguments);
-        this.handleChange();
-      },
-
-      willDestroy() {
-        this._super(...arguments);
-        if (this.unsubscribe) {
-          this.unsubscribe();
-          this.unsubscribe = null;
-        }
       }
     });
   };

--- a/addon/components/connect.js
+++ b/addon/components/connect.js
@@ -6,6 +6,7 @@ const {
   computed,
   defineProperty,
   getProperties,
+  guidFor,
   inject: { service },
   run
 } = Ember;
@@ -33,7 +34,7 @@ function changedKeys(state, newState) {
 function computedReduxProperty(key, getState) {
   return computed({
     get: () => getState()[key],
-    set: () => assert(`Cannot set redux property "${key}".`)
+    set: () => assert(`Cannot set redux property "${key}". Try dispatching a redux action instead.`)
   });
 }
 
@@ -60,6 +61,16 @@ function getAttrs(context) {
   const attrKeys = Object.keys(context.attrs || {});
   return getProperties(context, attrKeys);
 }
+
+/**
+  A hash that has keys that are guids for a particular component instance
+  that stores the `handleChange` and `unsubscribe` methods for that
+  component so that they can be used in the component's lifecycle hooks
+  without exposing them to the wrapped component.
+
+  @type {Object}
+*/
+const hooksForComponent = {};
 
 export default (stateToComputed, dispatchToActions) => {
   return Component => {
@@ -95,11 +106,7 @@ export default (stateToComputed, dispatchToActions) => {
 
           const unsubscribe = redux.subscribe(handleChange);
 
-          this.on('didUpdateAttrs', handleChange);
-          this.one('willDestroyElement', () => {
-            this.off('didReceiveAttrs', handleChange);
-            unsubscribe();
-          });
+          hooksForComponent[guidFor(this)] = { handleChange, unsubscribe };
         }
 
         if (typeof dispatchToActions === 'function') {
@@ -114,6 +121,25 @@ export default (stateToComputed, dispatchToActions) => {
         }
 
         this._super(...arguments);
+      },
+
+      didUpdateAttrs() {
+        this._super(...arguments);
+
+        const hooks = hooksForComponent[guidFor(this)];
+        if (hooks) {
+          hooks.handleChange();
+        }
+      },
+
+      willDestroy() {
+        this._super(...arguments);
+
+        const hooks = hooksForComponent[guidFor(this)];
+        if (hooks) {
+          hooks.unsubscribe();
+          delete hooksForComponent[guidFor(this)];
+        }
       }
     });
   };

--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -73,6 +73,29 @@ test('stateToComputed can be used with component level CP if notifyPropertyChang
   assert.equal(this.$('.dyno').text(), 'name: Tom', 'should render new value when local component CP changed and notifyPropertyChange invoked');
 });
 
+test('stateToComputed is not invoked extraneously', function(assert) {
+  let callCount = 0;
+  const stateToComputed = () => {
+    callCount++;
+    return { callCount };
+  }
+  this.register('component:test-component', connect(stateToComputed)(Component.extend({
+    layout: hbs`{{callCount}}`
+  })));
+
+  this.render(hbs`{{test-component attr=attr}}`);
+  assert.equal(this.$().text(), '1');
+  assert.equal(callCount, 1);
+
+  this.set('attr', 'some-change');
+  assert.equal(this.$().text(), '2');
+  assert.equal(callCount, 2);
+
+  this.get('redux').dispatch({ type: 'FAKE-ACTION' });
+  assert.equal(this.$().text(), '3');
+  assert.equal(callCount, 3);
+});
+
 test('the component should truly be extended meaning actions map over as you would expect', function(assert) {
   this.render(hbs`{{count-list}}`);
   let $random = this.$('.random-state');

--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -113,21 +113,33 @@ test('each computed is truly readonly', function(assert) {
     assert.throws(() => {
       this.$('.btn-alter').trigger('click');
     }, (e) => {
-      return e.message.indexOf('Cannot set redux property "low"') > -1;
+      return e.message.indexOf('Cannot set redux property "low". Try dispatching a redux action instead.') > -1;
     });
   });
 });
 
 test('lifecycle hooks are still invoked', function(assert) {
-  assert.expect(1);
-  this.register('component:test-component', connect()(Component.extend({
+  assert.expect(3);
+  this.register('component:test-component', connect()(Ember.Component.extend({
     init() {
       assert.ok(true, 'init is invoked');
+      this._super(...arguments);
+    },
+
+    didUpdateAttrs() {
+      assert.ok(true, 'didUpdateAttrs should be invoked');
+      this._super(...arguments);
+    },
+
+    willDestroy() {
+      assert.ok(true, 'willDestroy is invoked');
       this._super(...arguments);
     }
   })));
 
   this.render(hbs`{{test-component name=name}}`);
+
+  this.set('name', 'Dustin');
 });
 
 test('connecting dispatchToActions only', function(assert) {

--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -3,6 +3,8 @@ import connect from 'ember-redux/components/connect';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
+const { Component } = Ember;
+
 moduleForComponent('count-list', 'integration: connect test', {
   integration: true,
   setup() {
@@ -88,47 +90,35 @@ test('each computed is truly readonly', function(assert) {
     assert.throws(() => {
       this.$('.btn-alter').trigger('click');
     }, (e) => {
-      return e.message.indexOf('Cannot set read-only property') > -1;
+      return e.message.indexOf('Cannot set redux property "low"') > -1;
     });
   });
 });
 
 test('lifecycle hooks are still invoked', function(assert) {
-  assert.expect(3);
-  this.register('component:test-component', connect()(Ember.Component.extend({
+  assert.expect(1);
+  this.register('component:test-component', connect()(Component.extend({
     init() {
       assert.ok(true, 'init is invoked');
-      this._super(...arguments);
-    },
-
-    didUpdateAttrs() {
-      assert.ok(true, 'didUpdateAttrs should be invoked');
-      this._super(...arguments);
-    },
-
-    willDestroy() {
-      assert.ok(true, 'willDestroy is invoked');
       this._super(...arguments);
     }
   })));
 
   this.render(hbs`{{test-component name=name}}`);
-
-  this.set('name', 'Dustin');
 });
 
 test('connecting dispatchToActions only', function(assert) {
   assert.expect(2);
   const dispatchToActions = () => {};
 
-  this.register('component:test-component-1', connect(null, dispatchToActions)(Ember.Component.extend({
+  this.register('component:test-component-1', connect(null, dispatchToActions)(Component.extend({
     init() {
       this._super(...arguments);
       assert.ok(true, 'should be able to connect components passing `null` to stateToComputed');
     }
   })));
 
-  this.register('component:test-component-2', connect(undefined, dispatchToActions)(Ember.Component.extend({
+  this.register('component:test-component-2', connect(undefined, dispatchToActions)(Component.extend({
     init() {
       this._super(...arguments);
       assert.ok(true, 'should be able to connect components passing `undefined` to stateToComputed');


### PR DESCRIPTION
We tried this a while ago in #41, but had to revert. It seems the revert was due to a collision in the `_props` key in #48 (@dustinfarris were you ever able to confirm this?).

Inspired by that issue, I'm proposing this variant which uses only a local variable `state` to maintain the state, which would prevent other addons/components/etc. from having a collision with the property since it's not defined on the component itself, and prevents folks using this addon from accessing the mapped state directly from within a component. Generally, it no longer exposes private methods like `getAttrs`, `handleChange`, nor private properties like `this.unsubscribe` to the consuming component.