### PR TITLE
Clean up functions used in connect.

### DIFF
--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -199,22 +199,24 @@ test('connecting dispatchToActions as object should dispatch action', function(a
   });
 });
 
-test('calling handleChange directly shows a deprecation warning', function(assert) {
-  assert.expect(1);
+test('calling deprecated methods shows message', function(assert) {
+  const warnings = [];
 
   const originalWarn = Ember.warn;
-  Ember.warn = (message, falsy, { id }) => {
-    assert.equal(id, 'ember-redux.no-public-handle-change');
-  }
+  Ember.warn = (message, falsy, { id }) => warnings.push({ message, id });
 
   this.register('component:test-component', connect()(Component.extend({
     init() {
       this.handleChange();
+      this.getAttrs();
       this._super(...arguments);
     }
   })));
 
   this.render(hbs`{{test-component}}`);
+
+  assert.equal(warnings[0].id, 'ember-redux.no-public-handle-change');
+  assert.equal(warnings[1].id, 'ember-redux.no-public-get-attrs');
 
   Ember.warn = originalWarn;
 });


### PR DESCRIPTION
This is some of the work I had bundled in #110. This makes `getAttrs` a private (static) function with a deprecation warning. I also pulled out the `changedKeys` utility function to be a bit more descriptive.