### PR TITLE
[FEATURE]: allow root reducer to explicitly call combineReducers from…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ https://ember-twiddle.com/6969acc7dda6aef431344cca031dcfcf
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import connect from 'ember-redux/components/connect';
-import ajax from 'example/utilities/ajax';
 import getUsersByAccountId from '../reducers';
+import fetch from 'fetch';
 
 var stateToComputed = (state, attrs) => {
   return {
@@ -43,7 +43,7 @@ var stateToComputed = (state, attrs) => {
 
 var dispatchToActions = (dispatch) => {
   return {
-    remove: (id) => ajax(`/api/users/${id}`, 'DELETE').then(() => dispatch({type: 'REMOVE_USER', id: id}))
+    remove: (id) => fetch(`/api/users/${id}`, {method: 'DELETE'}).then(fetched => fetched.json()).then(response => dispatch({type: 'REMOVE_USER', id: id}))
   };
 };
 
@@ -96,7 +96,7 @@ export default UserTableComponent;
 
 ## License
 
-Copyright © 2016 Toran Billups http://toranbillups.com
+Copyright © 2017 Toran Billups http://toranbillups.com
 
 Licensed under the MIT License
 

--- a/app/services/redux.js
+++ b/app/services/redux.js
@@ -23,7 +23,8 @@ var createStoreWithMiddleware = compose(applyMiddleware(...middleware), enhancer
 
 export default Ember.Service.extend({
   init() {
-    this.store = createStoreWithMiddleware(combineReducers(reducers));
+    const reducer = typeof reducers === 'function' ? reducers : combineReducers(reducers);
+    this.store = createStoreWithMiddleware(reducer);
     setup(this.store);
     this._super(...arguments);
   },

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -53,12 +53,12 @@ const createSaga = createSagaMiddleWare.default ? createSagaMiddleWare.default :
 const sagaMiddleware = createSaga();
 
 const setup = () => {
-    sagaMiddleware.run(addAsync);
+  sagaMiddleware.run(addAsync);
 };
 
 export default {
-    middleware: [sagaMiddleware],
-    setup: setup
+  middleware: [sagaMiddleware],
+  setup: setup
 };
 ```
 
@@ -68,16 +68,18 @@ In redux [reducers][] take the current state along with some action and return a
 
 ```js
 //app/reducers/index.js
-var number = ((state, action) => {
-    if(action.type === 'ADD') {
-        return state + 1;
-    }
-    return state || 0;
-});
+import { combineReducers } from 'redux';
 
-export default {
-    number
-}
+const number = (state, action) => {
+  if (action.type === 'ADD') {
+    return state + 1;
+  }
+  return state || 0;
+};
+
+export default combineReducers({
+  number
+});
 ```
 
 [chrome dev tools]: https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en

--- a/docs/ddau.md
+++ b/docs/ddau.md
@@ -50,7 +50,7 @@ import route from 'ember-redux/route';
 import ajax from 'example/utilities/ajax';
 
 var model = (dispatch) => {
-    return ajax('/api/users', 'GET').then(response => dispatch({type: 'DESERIALIZE_USERS', response: response}));
+  return ajax('/api/users', 'GET').then(response => dispatch({type: 'DESERIALIZE_USERS', response: response}));
 };
 
 export default route({model})();
@@ -65,21 +65,21 @@ When the ajax request has resolved we dispatch an action to the redux store with
 import { uniq, remove } from 'example/utilities/array';
 
 const initialState = {
-    all: []
+  all: []
 };
 
 export default ((state, action) => {
-    if (action.type === 'DESERIALIZE_USERS') {
-        return Object.assign({}, state, {
-            all: uniq(state.all, action.response)
-        });
-    }
-    if (action.type === 'REMOVE_USER') {
-        return Object.assign({}, state, {
-            all: remove(state.all, action.id)
-        });
-    }
-    return state || initialState;
+  if (action.type === 'DESERIALIZE_USERS') {
+    return Object.assign({}, state, {
+      all: uniq(state.all, action.response)
+    });
+  }
+  if (action.type === 'REMOVE_USER') {
+    return Object.assign({}, state, {
+      all: remove(state.all, action.id)
+    });
+  }
+  return state || initialState;
 });
 ```
 
@@ -89,11 +89,12 @@ This reducer is fine but without an entry in the index.js file (found in the red
 
 ```js
 //app/reducers/index.js
+import { combineReducers } from 'redux';
 import users from 'example/reducers/users';
 
-export default {
-    users: users
-};
+export default combineReducers({
+  users
+});
 ```
 
 Before we can start building the component tree we need to add the template file for the users route and define the `users-list` component.
@@ -112,7 +113,7 @@ Now that we have fetched the data we declare the `Container Component` that will
 import Ember from 'ember';
 import hbs from 'htmlbars-inline-precompile';
 import connect from 'ember-redux/components/connect';
-import ajax from 'example/utilities/ajax';
+import fetch from 'fetch';
 
 var stateToComputed = (state) => {
   return {
@@ -122,7 +123,7 @@ var stateToComputed = (state) => {
 
 var dispatchToActions = (dispatch) => {
   return {
-    remove: (id) => ajax(`/api/users/${id}`, 'DELETE').then(() => dispatch({type: 'REMOVE_USER', id: id}))
+    remove: (id) => fetch(`/api/users/${id}`, {method: 'DELETE'}).then(fetched => fetched.json()).then(response => dispatch({type: 'REMOVE_USER', id: id}))
   };
 };
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,10 +22,10 @@ If you ran the code above you likely hit a runtime error in redux. This error oc
 
 ```js
 var reducer = ((state, action) => {
-    if(action.type === 'ADD') {
-        return state + 1;
-    }
-    return state || 0;
+  if(action.type === 'ADD') {
+    return state + 1;
+  }
+  return state || 0;
 });
 ```
 
@@ -41,10 +41,10 @@ import Redux from 'redux';
 var { createStore } = Redux;
 
 var reducer = ((state, action) => {
-    if(action.type === 'ADD') {
-        return state + 1;
-    }
-    return state || 0;
+  if(action.type === 'ADD') {
+    return state + 1;
+  }
+  return state || 0;
 });
 
 var store = createStore(reducer);
@@ -60,21 +60,21 @@ import Redux from 'redux';
 var { createStore } = Redux;
 
 var reducer = ((state, action) => {
-    if(action.type === 'ADD') {
-        return state + 1;
-    }
-    return state || 0;
+  if(action.type === 'ADD') {
+    return state + 1;
+  }
+  return state || 0;
 });
 
 var store = createStore(reducer);
 
 export default Ember.Component.extend({
-    number: Ember.computed(function() {
-        return store.getState();
-    }),
-    layout: hbs`
-      {{number}}
-    `
+  number: Ember.computed(function() {
+    return store.getState();
+  }),
+  layout: hbs`
+    {{number}}
+  `
 });
 ```
 
@@ -88,27 +88,27 @@ import Redux from 'redux';
 var { createStore } = Redux;
 
 var reducer = ((state, action) => {
-    if(action.type === 'ADD') {
-        return state + 1;
-    }
-    return state || 0;
+  if(action.type === 'ADD') {
+    return state + 1;
+  }
+  return state || 0;
 });
 
 var store = createStore(reducer);
 
 export default Ember.Component.extend({
-    number: Ember.computed(function() {
-        return store.getState();
-    }),
-    actions: {
-        add: function() {
-            store.dispatch({type: 'ADD'});
-        }
-    },
-    layout: hbs`
-      {{number}}
-      <button onclick={{action "add"}}>add</button>
-    `
+  number: Ember.computed(function() {
+    return store.getState();
+  }),
+  actions: {
+    add: function() {
+      store.dispatch({type: 'ADD'});
+    }
+  },
+  layout: hbs`
+    {{number}}
+    <button onclick={{action "add"}}>add</button>
+  `
 });
 ```
 
@@ -124,33 +124,33 @@ import Redux from 'redux';
 var { createStore } = Redux;
 
 var reducer = ((state, action) => {
-    if(action.type === 'ADD') {
-        return state + 1;
-    }
-    return state || 0;
+  if(action.type === 'ADD') {
+    return state + 1;
+  }
+  return state || 0;
 });
 
 var store = createStore(reducer);
 
 export default Ember.Component.extend({
-    init: function() {
-        this._super(...arguments);
-        store.subscribe(() => {
-            this.notifyPropertyChange('number');
-        });
-    },
-    number: Ember.computed(function() {
-        return store.getState();
-    }),
-    actions: {
-        add: function() {
-            store.dispatch({type: 'ADD'});
-        }
-    },
-    layout: hbs`
-      {{number}}
-      <button onclick={{action "add"}}>add</button>
-    `
+  init: function() {
+    this._super(...arguments);
+    store.subscribe(() => {
+      this.notifyPropertyChange('number');
+    });
+  },
+  number: Ember.computed(function() {
+    return store.getState();
+  }),
+  actions: {
+    add: function() {
+      store.dispatch({type: 'ADD'});
+    }
+  },
+  layout: hbs`
+    {{number}}
+    <button onclick={{action "add"}}>add</button>
+  `
 });
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -11,16 +11,18 @@ Next we need to move the reducer itself by creating a new folder called `reducer
 ```js
 //app/reducers/index.js
 
-var number = ((state, action) => {
-    if(action.type === 'ADD') {
-        return state + 1;
-    }
-    return state || 0;
-});
+import { combineReducers } from 'redux';
 
-export default {
-    number
-}
+const number = (state, action) => {
+  if (action.type === 'ADD') {
+    return state + 1;
+  }
+  return state || 0;
+};
+
+export default combineReducers({
+  number
+});
 ```
 
 After we've got our reducer setup we need to remove the computed and action we created manually and replace them with a function that will be given state/dispatch directly.
@@ -43,10 +45,10 @@ var dispatchToActions = (dispatch) => {
 };
 
 var NumbersComponent = Ember.Component.extend({
-    layout: hbs`
-      {{number}}
-      <button onclick={{action "add"}}>add</button>
-    `
+  layout: hbs`
+    {{number}}
+    <button onclick={{action "add"}}>add</button>
+  `
 });
 
 export default connect(stateToComputed, dispatchToActions)(NumbersComponent);

--- a/tests/dummy/app/components/count-list/component.js
+++ b/tests/dummy/app/components/count-list/component.js
@@ -7,6 +7,7 @@ var stateToComputed = function(state, attrs) {
   return {
     low: state.low,
     high: state.high,
+    combined: state.combined.done,
     greeting: `Welcome back, ${attrs.name}!`,
     serviced: component.get('fake.serviced'),
     dyno: `name: ${component.get('dynoName')}`
@@ -16,7 +17,8 @@ var stateToComputed = function(state, attrs) {
 var dispatchToActions = (dispatch) => {
   return {
     up: () => dispatch({type: 'UP'}),
-    down: () => dispatch({type: 'DOWN'})
+    down: () => dispatch({type: 'DOWN'}),
+    combine: () => dispatch({type: 'COMBINE'})
   };
 };
 
@@ -30,12 +32,14 @@ var CountListComponent = Ember.Component.extend({
     <span class="parent-state">{{low}}</span>
     <button class="btn-up" onclick={{action "up"}}>up</button>
     {{count-detail high=high down=(action "down")}}
+    <button class="btn-combine" onclick={{action "combine"}}>combine</button>
     <button class="btn-random" onclick={{action "random"}}>random</button>
     <button class="btn-alter" onclick={{action "alter"}}>alter</button>
     <span class="random-state">{{color}}</span>
     <span class="greeting">{{greeting}}</span>
     <span class="serviced">{{serviced}}</span>
     <span class="dyno">{{dyno}}</span>
+    <span class="combined">{{combined}}</span>
   `,
   actions: {
     alter() {

--- a/tests/dummy/app/reducers/combined.js
+++ b/tests/dummy/app/reducers/combined.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+var combined = function combined(state, action) {
+  if (action.type === 'COMBINE') {
+    Ember.assert('the reducers patch failed or was not applied');
+  }
+  return state || { done: false };
+};
+
+export default combined;

--- a/tests/dummy/app/reducers/index.js
+++ b/tests/dummy/app/reducers/index.js
@@ -1,5 +1,6 @@
 import low from 'dummy/reducers/low';
 import high from 'dummy/reducers/high';
+import combined from 'dummy/reducers/combined';
 import all from 'dummy/reducers/all';
 import users from 'dummy/reducers/users';
 import roles from 'dummy/reducers/roles';
@@ -11,6 +12,7 @@ import queryParams from 'dummy/reducers/query-params';
 export default {
   low: low,
   high: high,
+  combined: combined,
   all: all,
   users: users,
   roles: roles,

--- a/tests/helpers/patch-reducer.js
+++ b/tests/helpers/patch-reducer.js
@@ -1,0 +1,34 @@
+/* global require, define */
+
+import originalReducer from 'dummy/reducers/index';
+
+const { unsee } = require;
+
+export function applyPatch() {
+  unsee('dummy/services/redux');
+  unsee('dummy/reducers/index');
+
+  define('dummy/reducers/index', ['exports', 'dummy/reducers/low', 'dummy/reducers/high', 'redux'], function (exports, _low, _high, _redux) {
+    var combined = function combined(state, action) {
+      if (action.type === 'COMBINE') {
+        return Object.assign({}, state, { done: true });
+      }
+      return state || { done: false };
+    };
+
+    exports['default'] = (0, _redux.combineReducers)({
+      low: _low.default,
+      high: _high.default,
+      combined: combined
+    });
+  });
+}
+
+export function revertPatch() {
+  unsee('dummy/services/redux');
+  unsee('dummy/reducers/index');
+
+  define('dummy/reducers/index', ['exports'], function (exports) {
+    exports['default'] = originalReducer;
+  });
+}

--- a/tests/zlast/combine-reducers-test.js
+++ b/tests/zlast/combine-reducers-test.js
@@ -1,0 +1,38 @@
+import Ember from 'ember';
+import { test, module } from 'qunit';
+import { applyPatch, revertPatch } from '../helpers/patch-reducer';
+import startApp from '../helpers/start-app';
+
+var application;
+
+module('Acceptance | combine reducers test', {
+  beforeEach() {
+    applyPatch();
+    application = startApp();
+  },
+  afterEach() {
+    Ember.run(application, 'destroy');
+    revertPatch();
+  }
+});
+
+test('reducer can use combineReducers function directly', function(assert) {
+  visit('/');
+  andThen(() => {
+    assert.equal(currentURL(), '/');
+    assert.equal(find('.parent-state').text(), '0');
+    assert.equal(find('.combined').text().trim(), 'false');
+  });
+  click('.btn-combine');
+  andThen(() => {
+    assert.equal(currentURL(), '/');
+    assert.equal(find('.parent-state').text(), '0');
+    assert.equal(find('.combined').text().trim(), 'true');
+  });
+  click('.btn-up');
+  andThen(() => {
+    assert.equal(currentURL(), '/');
+    assert.equal(find('.parent-state').text(), '1');
+    assert.equal(find('.combined').text().trim(), 'true');
+  });
+});


### PR DESCRIPTION
In issue #115 it was requested that we allow `combineReducers` from the root reducers/index 

This shows that working end-to-end w/out breaking people in the 2X series today (who are not using `combineReducers` directly)