### PR TITLE
[BUILD]: updated ember-cli-babel to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "redux"
   ],
   "dependencies": {
-    "ember-cli-babel": "^6.0.0-beta.3"
+    "ember-cli-babel": "^6.1.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
noticed the v6.1.0 of ember-cli-babel was out - simple upgrade here