### PR TITLE
Add "replaceReducer" method to redux service.

### DIFF
--- a/app/services/redux.js
+++ b/app/services/redux.js
@@ -36,5 +36,8 @@ export default Ember.Service.extend({
   },
   subscribe(func) {
     return this.store.subscribe(func);
+  },
+  replaceReducer(nextReducer) {
+    return this.store.replaceReducer(nextReducer);
   }
 });

--- a/tests/unit/services/redux-test.js
+++ b/tests/unit/services/redux-test.js
@@ -12,3 +12,17 @@ test('should return the action on dispatch', function(assert) {
   const dispatchResult = service.dispatch({ type: 'DUMMY' });
   assert.deepEqual(dispatchResult, { type: 'DUMMY' });
 });
+
+test('should replace the store\'s reducer', function(assert) {
+  const service = this.subject();
+
+  service.replaceReducer(() => {
+    return 'DUMMY_REDUCER_1';
+  });
+  assert.equal(service.getState(), 'DUMMY_REDUCER_1');
+
+  service.replaceReducer(() => {
+    return 'DUMMY_REDUCER_2';
+  });
+  assert.equal(service.getState(), 'DUMMY_REDUCER_2');
+});


### PR DESCRIPTION
This is the one method missing from the standard redux store: http://redux.js.org/docs/api/Store.html#store-methods. Needed if added reducers dynamically to the store (e.g. changing app state structure per route or dynamically loading component reducers).