### PR TITLE
Support factories for stateToComputed.

### DIFF
--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -199,6 +199,35 @@ test('connecting dispatchToActions as object should dispatch action', function(a
   });
 });
 
+test('stateToComputed supports a static function', function(assert) {
+  const stateToComputed = () => ({ id: 'static-selector' });
+
+  this.register('component:component-with-static-selector', connect(stateToComputed)(Component.extend({
+    layout: hbs`{{id}}`
+  })));
+
+  this.render(hbs`{{component-with-static-selector}}`);
+
+  assert.equal(this.$().text(), 'static-selector');
+});
+
+test('stateToComputed supports a factory function', function(assert) {
+  let createdCount = 0;
+  const stateToComputedFactory = () => {
+    createdCount++;
+    return () => ({ id: `selector-${createdCount}` })
+  }
+
+  this.register('component:component-with-selector-factory', connect(stateToComputedFactory)(Component.extend({
+    layout: hbs`{{id}}`
+  })));
+
+  this.render(hbs`{{component-with-selector-factory}} {{component-with-selector-factory}}`);
+
+  assert.equal(createdCount, 2);
+  assert.equal(this.$().text(), 'selector-1 selector-2');
+});
+
 test('calling deprecated methods shows message', function(assert) {
   const warnings = [];
 


### PR DESCRIPTION
This allows reselect creators to be used, where a new instance
will be created for each instance of a connected component.

For more information on why this is useful, see: https://github.com/reactjs/reselect#sharing-selectors-with-props-across-multiple-components

This enables things like https://github.com/HeyImAlex/reselect-map to be used, which are critical for performance when mapping over large arrays in selectors (like a large list).