### PR TITLE
[FEATURE]: connect now provides default Ember.Component

### DIFF
--- a/addon/connect.js
+++ b/addon/connect.js
@@ -80,8 +80,9 @@ function wrapStateToComputed(stateToComputed) {
 }
 
 export default (stateToComputed, dispatchToActions=() => ({})) => {
-  return Component => {
-    return Component.extend({
+  return IncomingComponent => {
+    const WrappedComponent = IncomingComponent || Ember.Component;
+    return WrappedComponent.extend({
       redux: service(),
 
       init() {

--- a/tests/integration/connect-test.js
+++ b/tests/integration/connect-test.js
@@ -199,6 +199,18 @@ test('connecting dispatchToActions as object should dispatch action', function(a
   });
 });
 
+test('connect provides an Ember.Component for you by default', function(assert) {
+  this.registry.register('template:components/foo-bar', hbs`{{name}}`);
+
+  const stateToComputed = () => ({ name: 'byDefault?' });
+
+  this.register('component:foo-bar', connect(stateToComputed)());
+
+  this.render(hbs`{{foo-bar}}`);
+
+  assert.equal(this.$().text(), 'byDefault?');
+});
+
 test('stateToComputed supports a static function', function(assert) {
   const stateToComputed = () => ({ id: 'static-selector' });
 


### PR DESCRIPTION
For developers not using inline hbs (single file components) it's often the case that you only import Ember to pass `Ember.Component` into connect. For the typescript guides I'm writing I found it was easier to default a Component type if not provided (to eliminate importing all of Ember for no real gain).