### PR TITLE
[FEATURE]: add typescript type defs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,62 @@
+// Type definitions for ember-redux 2.9.0
+// Project: https://github.com/ember-redux/ember-redux
+// Definitions by: Toran Billups <https://github.com/toranb>
+// TypeScript Version: 2.3
+
+import * as Redux from 'redux';
+
+export = EmberRedux;
+
+declare namespace EmberRedux {
+  type Dispatch<S> = Redux.Dispatch<S>;
+  type ActionCreator<A> = Redux.ActionCreator<A>;
+
+  export interface DispatchProp<T> {
+    dispatch: Dispatch<T>
+  }
+
+  export function connect<TStateProps>(
+      mapStateToProps: MapStateToPropsParam<TStateProps>
+  ): any;
+
+  export function connect<no_state, TDispatchProps>(
+      mapStateToProps: null | undefined,
+      mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps>
+  ): any;
+
+  export function connect<TStateProps, TDispatchProps>(
+      mapStateToProps: MapStateToPropsParam<TStateProps>,
+      mapDispatchToProps: MapDispatchToPropsParam<TDispatchProps>
+  ): any;
+
+  interface MapStateToProps<TStateProps> {
+      (state: any): TStateProps;
+  }
+
+  interface MapStateToPropsFactory<TStateProps> {
+      (initialState: any): MapStateToProps<TStateProps>;
+  }
+
+  type MapStateToPropsParam<TStateProps> = MapStateToProps<TStateProps> | MapStateToPropsFactory<TStateProps>;
+
+  interface MapDispatchToPropsFunction<TDispatchProps> {
+      (dispatch: Dispatch<any>): TDispatchProps;
+  }
+
+  interface MapDispatchToPropsObject {
+      [name: string]: ActionCreator<any>;
+  }
+
+  type MapDispatchToProps<TDispatchProps> =
+      MapDispatchToPropsFunction<TDispatchProps> | MapDispatchToPropsObject;
+
+  interface MapDispatchToPropsFactory<TDispatchProps> {
+      (dispatch: Dispatch<any>): MapDispatchToProps<TDispatchProps>;
+  }
+
+  type MapDispatchToPropsParam<TDispatchProps> = MapDispatchToProps<TDispatchProps> | MapDispatchToPropsFactory<TDispatchProps>;
+
+  export function route<Function>(
+      routeFunc: Function
+  ): any;
+}


### PR DESCRIPTION
This isn't ready for prime time but I'm using it WIP style to build out the typescript ember-redux guides. It's mostly a copy/paste of react-redux and keeps the compiler happy for now (using the most strict settings I could crank up). Anyone more familiar have time to look this over/ help me land a solid TS type defs file for this addon?

Below is my tsconfig for the guides that I'm iterating on with 100% typescript + redux + ember

```js
{
  "compilerOptions": {
    "target": "es2015",
    "module": "es2015",
    "moduleResolution": "node",
    "strictNullChecks": true,
    "suppressImplicitAnyIndexErrors": true,
    "allowSyntheticDefaultImports": true,
    "noImplicitAny": true,
    "noEmitOnError": false,
    "noEmit": true,
    "baseUrl": ".",
    "paths": {
      "welp/*": ["app/*"],
      "ember-redux": ["node_modules/ember-redux/index.d.ts"],
      "redux": ["node_modules/redux/index.d.ts"],
      "fetch": ["node_modules/ember-fetch-tsdefs/index.d.ts"]
    }
  },
  "include": [
    "**/*.ts"
  ]
}
```

note: you might notice that ember is absent from this TS def file - I'm actually willing to ship ahead of ember's TS support going v1.0 (but if someone who knows the ember type defs can help me add that I'm open to working that in)