### PR TITLE
[WEBSITE]: added testing repository to the examples page

### DIFF
--- a/docs/_layouts/examples.html
+++ b/docs/_layouts/examples.html
@@ -49,6 +49,7 @@
             <div class="github">
               <a href="https://github.com/ember-redux/guides/commits/typescript">TypeScript</a>
               <a href="https://github.com/ember-redux/redux-and-engines/commits/master">Engines</a>
+              <a href="https://github.com/toranb/redux-saga-testing-example">Testing</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
I've added a testing example to the documentation website for reference

https://github.com/toranb/redux-saga-testing-example/commit/e8a0f48ca0a48e589fe90dd2713045961c1c90e7