### PR TITLE
Upgrade to ember-cli v2.18.2, bring back headless chrome, dump global helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 dist: trusty
 
 addons:
-  firefox: "56.0"
+  chrome: stable
 
 cache:
   yarn: true
@@ -20,8 +20,6 @@ env:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
 
 install:
   - yarn install --no-lockfile --non-interactive

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "ember-cli": "~2.18.0",
+    "ember-cli": "~2.18.2",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^2.0.1",

--- a/testem.js
+++ b/testem.js
@@ -2,9 +2,23 @@ module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: [
-    'Firefox'
+    'Chrome'
   ],
   launch_in_dev: [
-    'Firefox'
-  ]
+    'Chrome'
+  ],
+  browser_args: {
+    Chrome: {
+      mode: 'ci',
+      args: [
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.TRAVIS ? '--no-sandbox' : null,
+
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=0',
+        '--window-size=1440,900'
+      ].filter(Boolean)
+    }
+  }
 };

--- a/tests/acceptance/async-dispatch-test.js
+++ b/tests/acceptance/async-dispatch-test.js
@@ -1,8 +1,7 @@
-/*global ajax:true*/
-
 import { run } from '@ember/runloop';
 import { test, module } from 'qunit';
 import startApp from '../helpers/start-app';
+import ajax from '../helpers/ajax';
 
 var application;
 

--- a/tests/acceptance/rerender-test.js
+++ b/tests/acceptance/rerender-test.js
@@ -1,8 +1,7 @@
-/*global ajax:true*/
-
 import { run } from '@ember/runloop';
 import { test, module } from 'qunit';
 import startApp from '../helpers/start-app';
+import ajax from '../helpers/ajax';
 
 var application, oneUpdated = 0, oneFakeUpdated = 0, twoUpdated = 0, fourUpdated = 0, fiveUpdated = 0;
 

--- a/tests/acceptance/route-hooks-test.js
+++ b/tests/acceptance/route-hooks-test.js
@@ -1,7 +1,6 @@
-/*global ajax:true*/
-
 import { test } from 'qunit';
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import ajax from '../helpers/ajax';
 
 moduleForAcceptance('Acceptance | route hooks');
 

--- a/tests/acceptance/thunk-dispatch-test.js
+++ b/tests/acceptance/thunk-dispatch-test.js
@@ -1,7 +1,6 @@
-/*global ajax:true*/
-
 import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
 import { test } from 'qunit';
+import ajax from '../helpers/ajax';
 
 moduleForAcceptance('Acceptance | thunk dispatch test', {
   beforeEach() {

--- a/tests/helpers/ajax.js
+++ b/tests/helpers/ajax.js
@@ -1,0 +1,34 @@
+import $ from 'jquery';
+import { run, later } from '@ember/runloop';
+import wait from 'ember-test-helpers/wait';
+
+let unhandled = {};
+
+function interceptAjax(hash) {
+  let request = unhandled[hash.url];
+  let delay = request.responseTime || 0;
+  later(() => {
+    delete unhandled[hash.url];
+    hash.success(request.response);
+  }, delay);
+}
+
+$.ajax = interceptAjax;
+
+const patchAjax = function patchAjax(url, method, status, response, responseTime) {
+  run(function() {
+    unhandled[url] = {response: response, responseTime: responseTime};
+  });
+
+  return wait();
+}
+
+export default function ajax(url, method, status, response, responseTime) {
+  if (unhandled[url]) {
+    setTimeout(() => {
+      return ajax(url, method, status, response, responseTime);
+    }, 0);
+  } else {
+    return patchAjax(url, method, status, response, responseTime);
+  }
+}

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,30 +1,7 @@
-import $ from 'jquery';
-import { run, later } from '@ember/runloop';
+import { run } from '@ember/runloop';
 import { merge } from '@ember/polyfills';
-import { registerAsyncHelper } from '@ember/test';
 import Application from '../../app';
 import config from '../../config/environment';
-
-let unhandled = {};
-
-function interceptAjax(hash) {
-  let request = unhandled[hash.url];
-  let delay = request.responseTime || 0;
-  later(() => {
-    hash.success(request.response);
-  }, delay);
-}
-
-$.ajax = interceptAjax;
-
-function ajax(app, url, method, status, response, responseTime) {
-  run(function() {
-    unhandled[url] = {response: response, responseTime: responseTime};
-  });
-  return app.testHelpers.wait();
-}
-
-registerAsyncHelper('ajax', ajax);
 
 export default function startApp(attrs) {
   let attributes = merge({}, config.APP);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2256,9 +2256,9 @@ ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
-ember-cli@~2.18.0:
-  version "2.18.0"
-  resolved "https://registry.npmjs.org/ember-cli/-/ember-cli-2.18.0.tgz#75c7cf7be8d195ae2eb072489e6b7243c95f63d4"
+ember-cli@~2.18.2:
+  version "2.18.2"
+  resolved "https://registry.npmjs.org/ember-cli/-/ember-cli-2.18.2.tgz#bb15313a15139a85248a86d203643f918ba40f57"
   dependencies:
     amd-name-resolver "1.0.0"
     babel-plugin-transform-es2015-modules-amd "^6.24.0"
@@ -2337,7 +2337,7 @@ ember-cli@~2.18.0:
     sort-package-json "^1.4.0"
     symlink-or-copy "^1.1.8"
     temp "0.8.3"
-    testem "^1.18.0"
+    testem "^2.0.0"
     tiny-lr "^1.0.3"
     tree-sync "^1.2.1"
     uuid "^3.0.0"
@@ -2727,6 +2727,18 @@ exec-sh@^0.2.0:
 execa@^0.8.0:
   version "0.8.0"
   resolved "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.npmjs.org/execa/-/execa-0.9.0.tgz#adb7ce62cf985071f60580deb4a88b9e34712d01"
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"
@@ -4006,6 +4018,10 @@ lodash.bind@~2.3.0:
     lodash._createwrapper "~2.3.0"
     lodash._renative "~2.3.0"
     lodash._slice "~2.3.0"
+
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
 
 lodash.clonedeep@^4.4.1:
   version "4.5.0"
@@ -5723,22 +5739,23 @@ temp@0.8.3:
     os-tmpdir "^1.0.0"
     rimraf "~2.2.6"
 
-testem@^1.18.0:
-  version "1.18.4"
-  resolved "https://registry.npmjs.org/testem/-/testem-1.18.4.tgz#e45fed922bec2f54a616c43f11922598ac97eb41"
+testem@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/testem/-/testem-2.0.0.tgz#b05c96200c7ac98bae998d71c94c0c5345907d13"
   dependencies:
     backbone "^1.1.2"
     bluebird "^3.4.6"
     charm "^1.0.0"
     commander "^2.6.0"
     consolidate "^0.14.0"
-    cross-spawn "^5.1.0"
+    execa "^0.9.0"
     express "^4.10.7"
     fireworm "^0.7.0"
     glob "^7.0.4"
     http-proxy "^1.13.1"
     js-yaml "^3.2.5"
     lodash.assignin "^4.1.0"
+    lodash.castarray "^4.4.0"
     lodash.clonedeep "^4.4.1"
     lodash.find "^4.5.1"
     lodash.uniqby "^4.7.0"


### PR DESCRIPTION
https://dockyard.com/blog/2018/01/18/test-helpers-the-next-generation

The latest direction for ember/qunit seems to suggest global helpers are on the way out ;) so this just prepares for the eventual upgrade