### PR TITLE
Add a link to the Reddit clone that is built in the intro video

### DIFF
--- a/docs/_layouts/examples.html
+++ b/docs/_layouts/examples.html
@@ -48,6 +48,7 @@
             </div>
             <header>Github</header>
             <div class="github">
+              <a href="https://github.com/ember-redux/reddit-clone">Reddit clone</a>
               <a href="https://github.com/ember-redux/guides/commits/typescript">TypeScript</a>
               <a href="https://github.com/ember-redux/redux-and-engines/commits/master">Engines</a>
               <a href="https://github.com/ember-redux/redux-saga-testing-example">Testing</a>


### PR DESCRIPTION
 Let's make it super easy to find the Reddit clone that is built in the intro video.
 I haven't been able to verify this locally fix; how do I access this page when running locally?