### PR TITLE
DEPENDENCY: ember-cli-update to v3.11.1 and fixed testem

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-redux-shim": "^4.0.1",
     "ember-redux-thunk-shim": "^2.5.0",
     "ember-resolver": "^4.0.0",
-    "ember-source": "~3.11.0",
+    "ember-source": "~3.11.1",
     "ember-symbol-observable": "^1.0.2",
     "ember-try": "^0.2.23",
     "eslint-plugin-ember": "^5.0.0",

--- a/testem.js
+++ b/testem.js
@@ -13,7 +13,6 @@ module.exports = {
         // --no-sandbox is needed when running Chrome inside a container
         process.env.CI ? '--no-sandbox' : null,
         '--headless',
-        '--disable-gpu',
         '--disable-dev-shm-usage',
         '--disable-software-rasterizer',
         '--mute-audio',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3351,7 +3351,7 @@ ember-router-generator@^1.2.3:
   dependencies:
     recast "^0.11.3"
 
-ember-source@~3.11.0:
+ember-source@~3.11.1:
   version "3.11.1"
   resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.11.1.tgz#2318fbe600c88d3a8abbf56fc2f3a61645ee42d8"
   integrity sha512-FPHHHu/5FBbKQ3o1D2HXEIniBUVqG1N4vDB66BaP0ht2ZcO6EB3HMjGxVH8Ad3Of8QOcXtZrBfXDHZdIWLW4lQ==


### PR DESCRIPTION
For some background into the testem issue 

https://bugs.chromium.org/p/chromium/issues/detail?id=982977