### PR TITLE
Adding support for glimmer component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ cache:
   yarn: true
 
 env:
+  - EMBER_TRY_SCENARIO=ember-3.6.X
+  - EMBER_TRY_SCENARIO=ember-3.8.X
+  - EMBER_TRY_SCENARIO=ember-3.12.X
   - EMBER_TRY_SCENARIO=ember-3.15.X
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ cache:
   yarn: true
 
 env:
-  - EMBER_TRY_SCENARIO=ember-3.6.X
-  - EMBER_TRY_SCENARIO=ember-3.8.X
-  - EMBER_TRY_SCENARIO=ember-3.12.X
+  - EMBER_TRY_SCENARIO=ember-3.15.X
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash

--- a/addon/connect.js
+++ b/addon/connect.js
@@ -1,10 +1,17 @@
 import Component from '@ember/component';
 import wrapEs2015Class from './es2015-class';
+import octaneConnect from './octane-connect'
 
+function isClassicComponent(component) {
+  // Not finding any other better way check component is classic or octane
+  return component.toString() === '@ember/component' && component.reopenClass;
+}
 export default (stateToComputed, dispatchToActions=() => ({})) => {
   return IncomingComponent => {
     const WrappedComponent = IncomingComponent || Component;
-
-    return wrapEs2015Class(stateToComputed, dispatchToActions, WrappedComponent);
+    if (isClassicComponent(WrappedComponent)) {
+      return wrapEs2015Class(stateToComputed, dispatchToActions, WrappedComponent);
+    }
+    return octaneConnect(stateToComputed, dispatchToActions, WrappedComponent);
   };
 };

--- a/addon/octane-connect.js
+++ b/addon/octane-connect.js
@@ -1,0 +1,93 @@
+import { notifyPropertyChange, get, defineProperty } from '@ember/object';
+import { inject } from '@ember/service';
+import { bindActionCreators } from 'redux';
+import { assert } from '@ember/debug';
+
+function changedKeys(props, newProps) {
+  return Object.keys(props).filter(key => {
+    return props[key] !== newProps[key];
+  });
+}
+
+function wrapStateToComputed(stateToComputed) {
+  return function(...args) {
+    const result = stateToComputed.call(this, ...args);
+    if (typeof result === 'function') {
+      return result.call(this, ...args);
+    }
+    return result;
+  };
+}
+
+
+function createProperty(getProps, name) {
+  let descriptor = {
+    enumerable: true,
+    configurable: false,
+    set() {
+      assert(`Cannot set redux property "${name}". Try dispatching a redux action instead.`);
+    },
+    get() {
+      return getProps()[name];
+    }
+  };
+  Object.defineProperty(this, name, descriptor);
+}
+
+export default function octaneConnect(stateToComputed, dispatchToActions, WrappedComponent) {
+
+  defineProperty(WrappedComponent.prototype, 'redux', inject('redux'));
+
+  return class Connect extends WrappedComponent {
+
+    constructor() {
+      super(...arguments);
+      const redux = get(this, 'redux');
+
+      if (stateToComputed) {
+        const wrappedStateToComputed = wrapStateToComputed(stateToComputed);
+
+        const getProps = () => wrappedStateToComputed.call(this, redux.getState(), this.args);
+
+        let props = getProps();
+
+        Object.keys(props).forEach(name => {
+          createProperty.call(this, getProps, name);
+        });
+
+        this._handleChange = () => {
+          let newProps = getProps();
+
+          if (props === newProps) return;
+
+          let notifyProperties = changedKeys(props, newProps);
+
+          props = newProps;
+          notifyProperties.forEach(name => notifyPropertyChange(this, name));
+        };
+
+        this.unsubscribe = redux.subscribe(() => {
+          this._handleChange();
+        });
+      }
+      if (typeof dispatchToActions === 'function') {
+        this.actions = Object.assign({},
+          this.actions, dispatchToActions.call(this, redux.dispatch.bind(redux))
+        );
+      }
+
+      if (typeof dispatchToActions === 'object') {
+        this.actions = Object.assign({},
+          this.actions, bindActionCreators(dispatchToActions, redux.dispatch.bind(redux))
+        );
+      }
+    }
+
+    willDestroy() {
+      if (this.unsubscribe) {
+        this.unsubscribe();
+        this.unsubscribe = null;
+      }
+    }
+  }
+}

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -22,6 +22,14 @@ module.exports = {
       }
     },
     {
+      name: 'ember-3.12.X',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.12.0'
+        }
+      }
+    },
+    {
       name: 'ember-3.15.X',
       npm: {
         devDependencies: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,6 +6,22 @@ module.exports = {
 
   scenarios: [
     {
+      name: 'ember-3.6.X',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.6.0'
+        }
+      }
+    },
+    {
+      name: 'ember-3.8.X',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.8.0'
+        }
+      }
+    },
+    {
       name: 'ember-3.15.X',
       npm: {
         devDependencies: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -6,26 +6,10 @@ module.exports = {
 
   scenarios: [
     {
-      name: 'ember-3.6.X',
+      name: 'ember-3.15.X',
       npm: {
         devDependencies: {
-          'ember-source': '~3.6.0'
-        }
-      }
-    },
-    {
-      name: 'ember-3.8.X',
-      npm: {
-        devDependencies: {
-          'ember-source': '~3.8.0'
-        }
-      }
-    },
-    {
-      name: 'ember-3.12.X',
-      npm: {
-        devDependencies: {
-          'ember-source': '~3.12.0'
+          'ember-source': '~3.15.0'
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^3.0.0",
+    "ember-compatibility-helpers": "^1.1.2",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.1",

--- a/tests/dummy/app/components/octane-clazz/component.js
+++ b/tests/dummy/app/components/octane-clazz/component.js
@@ -1,0 +1,53 @@
+import Component from '@glimmer/component';
+import { action, computed } from '@ember/object';
+import { connect } from 'ember-redux';
+import { tracked } from '@glimmer/tracking';
+
+const stateToComputed = (state, args) => {
+  return () => ({
+    number: state.low,
+    name: args.name
+  })
+};
+
+const dispatchToActions = (dispatch) => {
+  return {
+    up: () => dispatch({type: 'UP'})
+  };
+};
+
+class MyClazz extends Component {
+
+  @tracked color;
+
+  constructor() {
+    super(...arguments);
+    this.color = 'green';
+  }
+
+  get fullName() {
+    return this.args.name || 'full name'
+  }
+
+  @computed('number')
+  get intoFive() {
+    return this.number * 5;
+  }
+
+  @computed('args.name')
+  get sayHi() {
+    return 'Hi ' + this.name;
+  }
+
+  @action
+  go() {
+    this.actions.up();
+  }
+
+  @action
+  random() {
+    this.color = 'yellow';
+  }
+}
+
+export default connect(stateToComputed, dispatchToActions)(MyClazz);

--- a/tests/dummy/app/components/octane-clazz/template.hbs
+++ b/tests/dummy/app/components/octane-clazz/template.hbs
@@ -1,0 +1,9 @@
+<div class="name">name: {{this.name}}</div>
+<div class="full-name">full name: {{this.fullName}}</div>
+<div class="greeting">{{this.sayHi}}</div>
+<div class="color">color: {{this.color}}</div>
+<span class="into-five">number: {{this.intoFive}}</span>
+<span class="number">number: {{this.number}}</span><br />
+<span>bar: {{this.bar}}</span><br />
+<button class="button" type="button" {{on "click" this.go}}>GO</button>
+<button class="btn-random" {{on "click" this.random}}>random</button>

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,0 +1,5 @@
+{
+  "template-only-glimmer-components": true,
+  "application-template-wrapper": false,
+  "jquery-integration": false
+}

--- a/tests/integration/octane-clazz-test.js
+++ b/tests/integration/octane-clazz-test.js
@@ -1,0 +1,80 @@
+import hbs from 'htmlbars-inline-precompile';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, click, find } from '@ember/test-helpers';
+import { connect } from 'ember-redux';
+import Component from '@glimmer/component';
+
+module('Integration | Component | octane-clazz', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('octane state to be comppueted', async function(assert) {
+    await render(hbs`<OctaneClazz/>`);
+    assert.equal(document.querySelector('.number').textContent, 'number: 0');
+    await click('.button');
+    await click('.button');
+    await click('.button');
+    assert.equal(document.querySelector('.number').textContent, 'number: 3');
+    assert.equal(document.querySelector('.into-five').textContent, 'number: 15');
+    assert.equal(document.querySelector('.color').textContent, 'color: green');
+    assert.equal(document.querySelector('.full-name').textContent, 'full name: full name');
+  });
+
+  test('should render args', async function(assert) {
+    assert.expect(4);
+
+    this.set('myName', 'Raghs');
+
+    await render(hbs`<OctaneClazz @name={{this.myName}} />`);
+
+    assert.equal(document.querySelector('.full-name').textContent, 'full name: Raghs');
+    assert.equal(document.querySelector('.name').textContent, 'name: Raghs');
+
+    this.set('myName', 'Toran');
+
+    assert.equal(document.querySelector('.full-name').textContent, 'full name: Toran');
+    assert.equal(document.querySelector('.name').textContent, 'name: Toran');
+  });
+
+
+  test('stateToComputed can be used with component level CP', async function(assert) {
+    assert.expect(2);
+
+    this.set('myName', 'Raghs');
+
+    await render(hbs`<OctaneClazz @name={{this.myName}} />`);
+
+    assert.equal(document.querySelector('.greeting').textContent, 'Hi Raghs');
+
+    this.set('myName', 'Toran');
+
+    assert.equal(document.querySelector('.greeting').textContent, 'Hi Toran');
+
+  });
+
+  test('glimmer component connecting dispatchToActions only', async function(assert) {
+    assert.expect(1);
+
+    const dispatchToActions = () => {};
+
+    this.owner.register('component:test-component-1', connect(null, dispatchToActions)(class Foo extends Component {
+      constructor() {
+        super(...arguments);
+        assert.ok(true, 'should be able to connect components passing `null` to stateToComputed');
+      }
+    }));
+    await render(hbs`{{test-component-1}}`);
+  });
+
+  test('raghs the component should truly be extended meaning actions map over as you would expect', async function(assert) {
+    await render(hbs`<OctaneClazz @name={{this.myName}} />`);
+
+    let $random = find('.color');
+    assert.equal($random.textContent, 'color: green');
+
+    await click('.btn-random');
+
+    assert.equal($random.textContent, 'color: yellow');
+  });
+
+});

--- a/tests/integration/octane-clazz-test.js
+++ b/tests/integration/octane-clazz-test.js
@@ -66,7 +66,7 @@ module('Integration | Component | octane-clazz', function(hooks) {
     await render(hbs`{{test-component-1}}`);
   });
 
-  test('raghs the component should truly be extended meaning actions map over as you would expect', async function(assert) {
+  test('the component should truly be extended meaning actions map over as you would expect', async function(assert) {
     await render(hbs`<OctaneClazz @name={{this.myName}} />`);
 
     let $random = find('.color');

--- a/tests/integration/octane-clazz-test.js
+++ b/tests/integration/octane-clazz-test.js
@@ -4,77 +4,102 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render, click, find } from '@ember/test-helpers';
 import { connect } from 'ember-redux';
 import Component from '@glimmer/component';
+import { gte } from 'ember-compatibility-helpers';
 
 module('Integration | Component | octane-clazz', function(hooks) {
   setupRenderingTest(hooks);
 
+
   test('octane state to be comppueted', async function(assert) {
-    await render(hbs`<OctaneClazz/>`);
-    assert.equal(document.querySelector('.number').textContent, 'number: 0');
-    await click('.button');
-    await click('.button');
-    await click('.button');
-    assert.equal(document.querySelector('.number').textContent, 'number: 3');
-    assert.equal(document.querySelector('.into-five').textContent, 'number: 15');
-    assert.equal(document.querySelector('.color').textContent, 'color: green');
-    assert.equal(document.querySelector('.full-name').textContent, 'full name: full name');
+    if(gte('3.15.0')) {
+      await render(hbs`<OctaneClazz/>`);
+      assert.equal(document.querySelector('.number').textContent, 'number: 0');
+      await click('.button');
+      await click('.button');
+      await click('.button');
+      assert.equal(document.querySelector('.number').textContent, 'number: 3');
+      assert.equal(document.querySelector('.into-five').textContent, 'number: 15');
+      assert.equal(document.querySelector('.color').textContent, 'color: green');
+      assert.equal(document.querySelector('.full-name').textContent, 'full name: full name');
+    } else {
+      assert.ok(true, 'Tests are not executed and marked as passed');
+    }
+
   });
 
   test('should render args', async function(assert) {
-    assert.expect(4);
+    if(gte('3.15.0')) {
+      assert.expect(4);
 
-    this.set('myName', 'Raghs');
+      this.set('myName', 'Raghs');
 
-    await render(hbs`<OctaneClazz @name={{this.myName}} />`);
+      await render(hbs`<OctaneClazz @name={{this.myName}} />`);
 
-    assert.equal(document.querySelector('.full-name').textContent, 'full name: Raghs');
-    assert.equal(document.querySelector('.name').textContent, 'name: Raghs');
+      assert.equal(document.querySelector('.full-name').textContent, 'full name: Raghs');
+      assert.equal(document.querySelector('.name').textContent, 'name: Raghs');
 
-    this.set('myName', 'Toran');
+      this.set('myName', 'Toran');
 
-    assert.equal(document.querySelector('.full-name').textContent, 'full name: Toran');
-    assert.equal(document.querySelector('.name').textContent, 'name: Toran');
+      assert.equal(document.querySelector('.full-name').textContent, 'full name: Toran');
+      assert.equal(document.querySelector('.name').textContent, 'name: Toran');
+    } else {
+      assert.ok(true, 'Tests are not executed and marked as passed');
+    }
+
   });
 
 
   test('stateToComputed can be used with component level CP', async function(assert) {
-    assert.expect(2);
+    if(gte('3.15.0')) {
+      assert.expect(2);
 
-    this.set('myName', 'Raghs');
+      this.set('myName', 'Raghs');
 
-    await render(hbs`<OctaneClazz @name={{this.myName}} />`);
+      await render(hbs`<OctaneClazz @name={{this.myName}} />`);
 
-    assert.equal(document.querySelector('.greeting').textContent, 'Hi Raghs');
+      assert.equal(document.querySelector('.greeting').textContent, 'Hi Raghs');
 
-    this.set('myName', 'Toran');
+      this.set('myName', 'Toran');
 
-    assert.equal(document.querySelector('.greeting').textContent, 'Hi Toran');
-
+      assert.equal(document.querySelector('.greeting').textContent, 'Hi Toran');
+    } else {
+      assert.ok(true, 'Tests are not executed and marked as passed');
+    }
   });
 
   test('glimmer component connecting dispatchToActions only', async function(assert) {
-    assert.expect(1);
+    if(gte('3.15.0')) {
+      assert.expect(1);
 
-    const dispatchToActions = () => {};
+      const dispatchToActions = () => {};
 
-    this.owner.register('component:test-component-1', connect(null, dispatchToActions)(class Foo extends Component {
-      constructor() {
-        super(...arguments);
-        assert.ok(true, 'should be able to connect components passing `null` to stateToComputed');
-      }
-    }));
-    await render(hbs`{{test-component-1}}`);
+      this.owner.register('component:test-component-1', connect(null, dispatchToActions)(class Foo extends Component {
+        constructor() {
+          super(...arguments);
+          assert.ok(true, 'should be able to connect components passing `null` to stateToComputed');
+        }
+      }));
+      await render(hbs`{{test-component-1}}`);
+    } else {
+      assert.ok(true, 'Tests are not executed and marked as passed');
+    }
+
   });
 
   test('the component should truly be extended meaning actions map over as you would expect', async function(assert) {
-    await render(hbs`<OctaneClazz @name={{this.myName}} />`);
+    if(gte('3.15.0')) {
+      await render(hbs`<OctaneClazz @name={{this.myName}} />`);
 
-    let $random = find('.color');
-    assert.equal($random.textContent, 'color: green');
+      let $random = find('.color');
+      assert.equal($random.textContent, 'color: green');
 
-    await click('.btn-random');
+      await click('.btn-random');
 
-    assert.equal($random.textContent, 'color: yellow');
+      assert.equal($random.textContent, 'color: yellow');
+    } else {
+      assert.ok(true, 'Tests are not executed and marked as passed');
+    }
+
   });
 
 });


### PR DESCRIPTION
To support Octane added the different code path for Glimmer Component. Most of the code taken from the spike oranb/octane-interop-redux@51e8fe1. Also added the factory function supported

I didn't find any better way to differentiates between glimmer and ember component 
`component.toString() === '@ember/component' && component.reopenClass;
`

Added required test to cover happy paths
